### PR TITLE
refactor: use dummy inference flow in unit test

### DIFF
--- a/inference_client/base.py
+++ b/inference_client/base.py
@@ -380,7 +380,7 @@ class BaseClient:
         return payload, content_type, is_list
 
     def _post(self, payload):
-        return self.client.post(payload)
+        return self.client.post(**payload)
 
     @staticmethod
     def _unboxed_result(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,25 @@
 import pytest
+from jina import Flow, helper
+
+from .executor import DummyExecutor
+
+
+@pytest.fixture(scope='session')
+def port_generator():
+    generated_ports = set()
+
+    def random_port():
+        port = helper.random_port()
+        while port in generated_ports:
+            port = helper.random_port()
+        generated_ports.add(port)
+        return port
+
+    return random_port
+
+
+@pytest.fixture(scope='session')
+def make_flow(port_generator):
+    f = Flow(port=port_generator()).add(name='dummy', uses=DummyExecutor)
+    with f:
+        yield f

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 import pytest
 from jina import Flow, helper
 
+from inference_client.base import BaseClient
+
 from .executor import DummyExecutor
 
 
@@ -23,3 +25,12 @@ def make_flow(port_generator):
     f = Flow(port=port_generator()).add(name='dummy', uses=DummyExecutor)
     with f:
         yield f
+
+
+@pytest.fixture(scope='session')
+def make_client(make_flow):
+    return BaseClient(
+        model_name='dummy-model',
+        token='valid_token',
+        host=f'grpc://0.0.0.0:{make_flow.port}',
+    )

--- a/tests/executor.py
+++ b/tests/executor.py
@@ -1,0 +1,30 @@
+import numpy as np
+from jina import Executor, requests
+
+
+class DummyExecutor(Executor):
+    @requests(on='/caption')
+    def caption(self, docs, **kwargs):
+        for doc in docs:
+            doc.tags['response'] = 'A image of something very nice'
+
+    @requests(on='/encode')
+    def encode(self, docs, **kwargs):
+        for doc in docs:
+            doc.embedding = np.random.random((512,))
+
+    @requests(on='/rank')
+    def rank(self, docs, **kwargs):
+        for doc in docs:
+            for m in doc.matches:
+                m.scores['cosine'].value = np.random.random()
+                m.scores['cosine'].op_name = 'cosine'
+            final = sorted(
+                doc.matches, key=lambda _m: _m.scores['cosine'].value, reverse=True
+            )
+            doc.matches = final
+
+    @requests(on='/vqa')
+    def vqa(self, docs, **kwargs):
+        for doc in docs:
+            doc.tags['response'] = 'Yes, it is a cat'

--- a/tests/executor.py
+++ b/tests/executor.py
@@ -10,8 +10,7 @@ class DummyExecutor(Executor):
 
     @requests(on='/encode')
     def encode(self, docs, **kwargs):
-        for doc in docs:
-            doc.embedding = np.random.random((512,))
+        docs.embeddings = np.random.random((len(docs), 512))
 
     @requests(on='/rank')
     def rank(self, docs, **kwargs):

--- a/tests/test_caption.py
+++ b/tests/test_caption.py
@@ -1,8 +1,6 @@
 import pytest
 from docarray import Document, DocumentArray
 
-from inference_client.base import BaseClient
-
 
 @pytest.mark.parametrize(
     'inputs',
@@ -17,13 +15,8 @@ from inference_client.base import BaseClient
         ],
     ],
 )
-def test_caption_document(make_flow, inputs):
-    model = BaseClient(
-        model_name='dummy-model',
-        token='valid_token',
-        host=f'grpc://0.0.0.0:{make_flow.port}',
-    )
-    res = model.caption(docs=inputs)
+def test_caption_document(make_client, inputs):
+    res = make_client.caption(docs=inputs)
     assert isinstance(res, DocumentArray)
     assert res[0].tags['response'] == 'A image of something very nice'
 
@@ -38,11 +31,6 @@ def test_caption_document(make_flow, inputs):
         .tensor,
     ],
 )
-def test_encode_plain_image(make_flow, inputs):
-    model = BaseClient(
-        model_name='dummy-model',
-        token='valid_token',
-        host=f'grpc://0.0.0.0:{make_flow.port}',
-    )
-    res = model.caption(image=inputs)
+def test_encode_plain_image(make_client, inputs):
+    res = make_client.caption(image=inputs)
     assert res == 'A image of something very nice'

--- a/tests/test_caption.py
+++ b/tests/test_caption.py
@@ -1,9 +1,7 @@
-from unittest.mock import Mock, patch
-
 import pytest
 from docarray import Document, DocumentArray
 
-from inference_client import Client
+from inference_client.base import BaseClient
 
 
 @pytest.mark.parametrize(
@@ -19,29 +17,15 @@ from inference_client import Client
         ],
     ],
 )
-@patch(
-    'inference_client.client.get_model_spec',
-    Mock(return_value={'endpoints': {'grpc': 'grpc://mock.inference.jina.ai'}}),
-)
-@patch('inference_client.client.login', Mock(return_value='valid_token'))
-@patch(
-    'inference_client.base.BaseClient._post',
-    Mock(
-        return_value=DocumentArray(
-            [
-                Document(
-                    uri='https://picsum.photos/id/233/100',
-                    tags={'response': 'a image of two rails'},
-                ),
-            ]
-        )
-    ),
-)
-def test_caption_document(inputs):
-    model = Client().get_model('mock-model')
+def test_caption_document(make_flow, inputs):
+    model = BaseClient(
+        model_name='dummy-model',
+        token='valid_token',
+        host=f'grpc://0.0.0.0:{make_flow.port}',
+    )
     res = model.caption(docs=inputs)
     assert isinstance(res, DocumentArray)
-    assert res[0].tags['response'] == 'a image of two rails'
+    assert res[0].tags['response'] == 'A image of something very nice'
 
 
 @pytest.mark.parametrize(
@@ -54,25 +38,11 @@ def test_caption_document(inputs):
         .tensor,
     ],
 )
-@patch(
-    'inference_client.client.get_model_spec',
-    Mock(return_value={'endpoints': {'grpc': 'grpc://mock.inference.jina.ai'}}),
-)
-@patch('inference_client.client.login', Mock(return_value='valid_token'))
-@patch(
-    'inference_client.base.BaseClient._post',
-    Mock(
-        return_value=DocumentArray(
-            [
-                Document(
-                    uri='https://picsum.photos/id/233/100',
-                    tags={'response': 'a image of two rails'},
-                ),
-            ]
-        )
-    ),
-)
-def test_encode_plain_image(inputs):
-    model = Client().get_model('mock-model')
+def test_encode_plain_image(make_flow, inputs):
+    model = BaseClient(
+        model_name='dummy-model',
+        token='valid_token',
+        host=f'grpc://0.0.0.0:{make_flow.port}',
+    )
     res = model.caption(image=inputs)
-    assert res == 'a image of two rails'
+    assert res == 'A image of something very nice'

--- a/tests/test_encode.py
+++ b/tests/test_encode.py
@@ -1,10 +1,9 @@
 from unittest.mock import Mock, patch
 
-import numpy as np
 import pytest
 from docarray import Document, DocumentArray
 
-from inference_client import Client
+from inference_client.base import BaseClient
 
 
 @pytest.mark.parametrize(
@@ -22,27 +21,12 @@ from inference_client import Client
         ],
     ],
 )
-@patch(
-    'inference_client.client.get_model_spec',
-    Mock(return_value={'endpoints': {'grpc': 'grpc://mock.inference.jina.ai'}}),
-)
-@patch('inference_client.client.login', Mock(return_value='valid_token'))
-@patch(
-    'inference_client.base.BaseClient._post',
-    Mock(
-        return_value=DocumentArray(
-            [
-                Document(text='hello world', embedding=np.random.random((512,))),
-                Document(
-                    uri='https://picsum.photos/id/233/100',
-                    embedding=np.random.random((512,)),
-                ).load_uri_to_blob(),
-            ]
-        )
-    ),
-)
-def test_encode_document(inputs):
-    model = Client().get_model('mock-model')
+def test_encode_document(make_flow, inputs):
+    model = BaseClient(
+        model_name='dummy-model',
+        token='valid_token',
+        host=f'grpc://0.0.0.0:{make_flow.port}',
+    )
     res = model.encode(docs=inputs)
     assert isinstance(res, DocumentArray)
     assert len(res) == 2
@@ -57,17 +41,12 @@ def test_encode_document(inputs):
     'inference_client.client.get_model_spec',
     Mock(return_value={'endpoints': {'grpc': 'grpc://mock.inference.jina.ai'}}),
 )
-@patch('inference_client.client.login', Mock(return_value='valid_token'))
-@patch(
-    'inference_client.base.BaseClient._post',
-    Mock(
-        return_value=DocumentArray(
-            [Document(text='hello world', embedding=np.random.random((512,)))]
-        )
-    ),
-)
-def test_encode_plain_text_single(inputs):
-    model = Client().get_model('mock-model')
+def test_encode_plain_text_single(make_flow, inputs):
+    model = BaseClient(
+        model_name='dummy-model',
+        token='valid_token',
+        host=f'grpc://0.0.0.0:{make_flow.port}',
+    )
     res = model.encode(text=inputs)
     assert res.shape == (512,)
 
@@ -77,20 +56,12 @@ def test_encode_plain_text_single(inputs):
     'inference_client.client.get_model_spec',
     Mock(return_value={'endpoints': {'grpc': 'grpc://mock.inference.jina.ai'}}),
 )
-@patch('inference_client.client.login', Mock(return_value='valid_token'))
-@patch(
-    'inference_client.base.BaseClient._post',
-    Mock(
-        return_value=DocumentArray(
-            [
-                Document(text='hello world', embedding=np.random.random((512,))),
-                Document(text='hello jina', embedding=np.random.random((512,))),
-            ]
-        )
-    ),
-)
-def test_encode_plain_text_list(inputs):
-    model = Client().get_model('mock-model')
+def test_encode_plain_text_list(make_flow, inputs):
+    model = BaseClient(
+        model_name='dummy-model',
+        token='valid_token',
+        host=f'grpc://0.0.0.0:{make_flow.port}',
+    )
     res = model.encode(text=inputs)
     assert len(res) == 2
     assert res[0].shape == (512,)
@@ -107,26 +78,12 @@ def test_encode_plain_text_list(inputs):
         .tensor,
     ],
 )
-@patch(
-    'inference_client.client.get_model_spec',
-    Mock(return_value={'endpoints': {'grpc': 'grpc://mock.inference.jina.ai'}}),
-)
-@patch('inference_client.client.login', Mock(return_value='valid_token'))
-@patch(
-    'inference_client.base.BaseClient._post',
-    Mock(
-        return_value=DocumentArray(
-            [
-                Document(
-                    uri='https://picsum.photos/id/233/100',
-                    embedding=np.random.random((512,)),
-                ),
-            ]
-        )
-    ),
-)
-def test_encode_plain_image(inputs):
-    model = Client().get_model('mock-model')
+def test_encode_plain_image(make_flow, inputs):
+    model = BaseClient(
+        model_name='dummy-model',
+        token='valid_token',
+        host=f'grpc://0.0.0.0:{make_flow.port}',
+    )
     res = model.encode(image=inputs)
     assert res.shape == (512,)
 
@@ -152,30 +109,12 @@ def test_encode_plain_image(inputs):
         ],
     ],
 )
-@patch(
-    'inference_client.client.get_model_spec',
-    Mock(return_value={'endpoints': {'grpc': 'grpc://mock.inference.jina.ai'}}),
-)
-@patch('inference_client.client.login', Mock(return_value='valid_token'))
-@patch(
-    'inference_client.base.BaseClient._post',
-    Mock(
-        return_value=DocumentArray(
-            [
-                Document(
-                    uri='https://picsum.photos/id/233/100',
-                    embedding=np.random.random((512,)),
-                ),
-                Document(
-                    uri='https://picsum.photos/id/233/100',
-                    embedding=np.random.random((512,)),
-                ),
-            ]
-        )
-    ),
-)
-def test_encode_plain_image_list(inputs):
-    model = Client().get_model('mock-model')
+def test_encode_plain_image_list(make_flow, inputs):
+    model = BaseClient(
+        model_name='dummy-model',
+        token='valid_token',
+        host=f'grpc://0.0.0.0:{make_flow.port}',
+    )
     res = model.encode(image=inputs)
     assert len(res) == 2
     assert res[0].shape == (512,)

--- a/tests/test_encode.py
+++ b/tests/test_encode.py
@@ -3,8 +3,6 @@ from unittest.mock import Mock, patch
 import pytest
 from docarray import Document, DocumentArray
 
-from inference_client.base import BaseClient
-
 
 @pytest.mark.parametrize(
     'inputs',
@@ -21,13 +19,8 @@ from inference_client.base import BaseClient
         ],
     ],
 )
-def test_encode_document(make_flow, inputs):
-    model = BaseClient(
-        model_name='dummy-model',
-        token='valid_token',
-        host=f'grpc://0.0.0.0:{make_flow.port}',
-    )
-    res = model.encode(docs=inputs)
+def test_encode_document(make_client, inputs):
+    res = make_client.encode(docs=inputs)
     assert isinstance(res, DocumentArray)
     assert len(res) == 2
     assert isinstance(res[0], Document)
@@ -41,13 +34,8 @@ def test_encode_document(make_flow, inputs):
     'inference_client.client.get_model_spec',
     Mock(return_value={'endpoints': {'grpc': 'grpc://mock.inference.jina.ai'}}),
 )
-def test_encode_plain_text_single(make_flow, inputs):
-    model = BaseClient(
-        model_name='dummy-model',
-        token='valid_token',
-        host=f'grpc://0.0.0.0:{make_flow.port}',
-    )
-    res = model.encode(text=inputs)
+def test_encode_plain_text_single(make_client, inputs):
+    res = make_client.encode(text=inputs)
     assert res.shape == (512,)
 
 
@@ -56,13 +44,8 @@ def test_encode_plain_text_single(make_flow, inputs):
     'inference_client.client.get_model_spec',
     Mock(return_value={'endpoints': {'grpc': 'grpc://mock.inference.jina.ai'}}),
 )
-def test_encode_plain_text_list(make_flow, inputs):
-    model = BaseClient(
-        model_name='dummy-model',
-        token='valid_token',
-        host=f'grpc://0.0.0.0:{make_flow.port}',
-    )
-    res = model.encode(text=inputs)
+def test_encode_plain_text_list(make_client, inputs):
+    res = make_client.encode(text=inputs)
     assert len(res) == 2
     assert res[0].shape == (512,)
     assert res[1].shape == (512,)
@@ -78,13 +61,8 @@ def test_encode_plain_text_list(make_flow, inputs):
         .tensor,
     ],
 )
-def test_encode_plain_image(make_flow, inputs):
-    model = BaseClient(
-        model_name='dummy-model',
-        token='valid_token',
-        host=f'grpc://0.0.0.0:{make_flow.port}',
-    )
-    res = model.encode(image=inputs)
+def test_encode_plain_image(make_client, inputs):
+    res = make_client.encode(image=inputs)
     assert res.shape == (512,)
 
 
@@ -109,13 +87,8 @@ def test_encode_plain_image(make_flow, inputs):
         ],
     ],
 )
-def test_encode_plain_image_list(make_flow, inputs):
-    model = BaseClient(
-        model_name='dummy-model',
-        token='valid_token',
-        host=f'grpc://0.0.0.0:{make_flow.port}',
-    )
-    res = model.encode(image=inputs)
+def test_encode_plain_image_list(make_client, inputs):
+    res = make_client.encode(image=inputs)
     assert len(res) == 2
     assert res[0].shape == (512,)
     assert res[1].shape == (512,)

--- a/tests/test_rank.py
+++ b/tests/test_rank.py
@@ -1,8 +1,6 @@
 import pytest
 from docarray import Document, DocumentArray
 
-from inference_client.base import BaseClient
-
 
 @pytest.mark.parametrize(
     'inputs',
@@ -35,13 +33,8 @@ from inference_client.base import BaseClient
         ],
     ],
 )
-def test_rank_document(make_flow, inputs):
-    model = BaseClient(
-        model_name='dummy-model',
-        token='valid_token',
-        host=f'grpc://0.0.0.0:{make_flow.port}',
-    )
-    res = model.rank(docs=inputs)
+def test_rank_document(make_client, inputs):
+    res = make_client.rank(docs=inputs)
     assert isinstance(res, DocumentArray)
     assert len(res[0].matches) == 3
     for m in res[0].matches:
@@ -65,24 +58,10 @@ def test_rank_document(make_flow, inputs):
                 .tensor,
             ],
         ],
-        # [
-        #     'https://picsum.photos/id/232/100',
-        #     [
-        #         'a colorful photo of nature',
-        #         'a lovely photo of cat',
-        #         'a black and white photo of dog',
-        #         'a cat playing with a dog',
-        #     ],
-        # ],
     ],
 )
-def test_rank_plain_text(make_flow, inputs):
-    model = BaseClient(
-        model_name='dummy-model',
-        token='valid_token',
-        host=f'grpc://0.0.0.0:{make_flow.port}',
-    )
-    res = model.rank(text=inputs[0], candidates=inputs[1])
+def test_rank_plain_text(make_client, inputs):
+    res = make_client.rank(text=inputs[0], candidates=inputs[1])
     assert isinstance(res, list)
     assert len(res) == 4
     assert isinstance(res[0], tuple)
@@ -105,13 +84,8 @@ def test_rank_plain_text(make_flow, inputs):
         ],
     ],
 )
-def test_rank_plain_image(make_flow, inputs):
-    model = BaseClient(
-        model_name='dummy-model',
-        token='valid_token',
-        host=f'grpc://0.0.0.0:{make_flow.port}',
-    )
-    res = model.rank(image=inputs[0], candidates=inputs[1])
+def test_rank_plain_image(make_client, inputs):
+    res = make_client.rank(image=inputs[0], candidates=inputs[1])
     assert isinstance(res, list)
     assert len(res) == 4
     assert isinstance(res[0], tuple)

--- a/tests/test_vqa.py
+++ b/tests/test_vqa.py
@@ -1,8 +1,6 @@
 import pytest
 from docarray import Document, DocumentArray
 
-from inference_client.base import BaseClient
-
 
 @pytest.mark.parametrize(
     'inputs',
@@ -23,13 +21,8 @@ from inference_client.base import BaseClient
         ],
     ],
 )
-def test_vqa_document(make_flow, inputs):
-    model = BaseClient(
-        model_name='dummy-model',
-        token='valid_token',
-        host=f'grpc://0.0.0.0:{make_flow.port}',
-    )
-    res = model.vqa(docs=inputs)
+def test_vqa_document(make_client, inputs):
+    res = make_client.vqa(docs=inputs)
     assert isinstance(res, DocumentArray)
     assert res[0].tags['response'] == 'Yes, it is a cat'
 
@@ -53,11 +46,6 @@ def test_vqa_document(make_flow, inputs):
         ],
     ],
 )
-def test_vqa_plain_image(make_flow, inputs):
-    model = BaseClient(
-        model_name='dummy-model',
-        token='valid_token',
-        host=f'grpc://0.0.0.0:{make_flow.port}',
-    )
-    res = model.vqa(image=inputs[0], question=inputs[1])
+def test_vqa_plain_image(make_client, inputs):
+    res = make_client.vqa(image=inputs[0], question=inputs[1])
     assert res == 'Yes, it is a cat'

--- a/tests/test_vqa.py
+++ b/tests/test_vqa.py
@@ -1,9 +1,7 @@
-from unittest.mock import Mock, patch
-
 import pytest
 from docarray import Document, DocumentArray
 
-from inference_client import Client
+from inference_client.base import BaseClient
 
 
 @pytest.mark.parametrize(
@@ -25,29 +23,15 @@ from inference_client import Client
         ],
     ],
 )
-@patch(
-    'inference_client.client.get_model_spec',
-    Mock(return_value={'endpoints': {'grpc': 'grpc://mock.inference.jina.ai'}}),
-)
-@patch('inference_client.client.login', Mock(return_value='valid_token'))
-@patch(
-    'inference_client.base.BaseClient._post',
-    Mock(
-        return_value=DocumentArray(
-            [
-                Document(
-                    uri='https://picsum.photos/id/233/100',
-                    tags={'response': 'a lot more than you think'},
-                ),
-            ]
-        ),
-    ),
-)
-def test_vqa_document(inputs):
-    model = Client().get_model('mock-model')
+def test_vqa_document(make_flow, inputs):
+    model = BaseClient(
+        model_name='dummy-model',
+        token='valid_token',
+        host=f'grpc://0.0.0.0:{make_flow.port}',
+    )
     res = model.vqa(docs=inputs)
     assert isinstance(res, DocumentArray)
-    assert res[0].tags['response'] == 'a lot more than you think'
+    assert res[0].tags['response'] == 'Yes, it is a cat'
 
 
 @pytest.mark.parametrize(
@@ -69,25 +53,11 @@ def test_vqa_document(inputs):
         ],
     ],
 )
-@patch(
-    'inference_client.client.get_model_spec',
-    Mock(return_value={'endpoints': {'grpc': 'grpc://mock.inference.jina.ai'}}),
-)
-@patch('inference_client.client.login', Mock(return_value='valid_token'))
-@patch(
-    'inference_client.base.BaseClient._post',
-    Mock(
-        return_value=DocumentArray(
-            [
-                Document(
-                    uri='https://picsum.photos/id/233/100',
-                    tags={'response': 'a lot more than you think'},
-                ),
-            ]
-        ),
-    ),
-)
-def test_vqa_plain_image(inputs):
-    model = Client().get_model('mock-model')
+def test_vqa_plain_image(make_flow, inputs):
+    model = BaseClient(
+        model_name='dummy-model',
+        token='valid_token',
+        host=f'grpc://0.0.0.0:{make_flow.port}',
+    )
     res = model.vqa(image=inputs[0], question=inputs[1])
-    assert res == 'a lot more than you think'
+    assert res == 'Yes, it is a cat'


### PR DESCRIPTION
This PR replace all mock functions in tasks unit tests with a dummy flow to mimic the behavior of actual inference flow