### PR TITLE
refactor: rename base client to model

### DIFF
--- a/inference_client/client.py
+++ b/inference_client/client.py
@@ -1,8 +1,8 @@
 from functools import lru_cache
 from typing import Optional
 
-from .base import BaseClient
 from .helper import get_model_spec, login
+from .model import Model
 
 
 class Client:
@@ -49,7 +49,7 @@ class Client:
             spec = get_model_spec(model_name, self._auth_token)
             endpoint = spec['endpoints']['grpc']
 
-        return BaseClient(
+        return Model(
             model_name=model_name,
             token=self._auth_token,
             host=endpoint,

--- a/inference_client/model.py
+++ b/inference_client/model.py
@@ -7,9 +7,9 @@ from .tasks.upscale import UpscaleMixin
 from .tasks.vqa import VQAMixin
 
 
-class BaseClient(CaptionMixin, EncodeMixin, RankMixin, UpscaleMixin, VQAMixin):
+class Model(CaptionMixin, EncodeMixin, RankMixin, UpscaleMixin, VQAMixin):
     """
-    Base client of inference-client.
+    The model to be used for inference.
     """
 
     def __init__(self, model_name: str, token: str, host: str, **kwargs):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 from jina import Flow, helper
 
-from inference_client.base import BaseClient
+from inference_client.model import Model
 
 from .executor import DummyExecutor
 
@@ -29,7 +29,7 @@ def make_flow(port_generator):
 
 @pytest.fixture(scope='session')
 def make_client(make_flow):
-    return BaseClient(
+    return Model(
         model_name='dummy-model',
         token='valid_token',
         host=f'grpc://0.0.0.0:{make_flow.port}',


### PR DESCRIPTION
This PR rename the baseclient class to model for better and easier understanding.